### PR TITLE
Refactored ...optimizer.lr to ...optimizer.learning_rate, as per the Keras source code.

### DIFF
--- a/keras_lr_finder/lr_finder.py
+++ b/keras_lr_finder/lr_finder.py
@@ -11,6 +11,7 @@ class LRFinder:
     See for details:
     https://towardsdatascience.com/estimating-optimal-learning-rate-for-a-deep-neural-network-ce32f2556ce0
     """
+
     def __init__(self, model):
         self.model = model
         self.losses = []
@@ -19,7 +20,7 @@ class LRFinder:
 
     def on_batch_end(self, batch, logs):
         # Log the learning rate
-        lr = K.get_value(self.model.optimizer.lr)
+        lr = K.get_value(self.model.optimizer.learning_rate)
         self.lrs.append(lr)
 
         # Log the loss
@@ -36,72 +37,72 @@ class LRFinder:
 
         # Increase the learning rate for the next batch
         lr *= self.lr_mult
-        K.set_value(self.model.optimizer.lr, lr)
+        K.set_value(self.model.optimizer.learning_rate, lr)
 
     def find(self, x_train, y_train, start_lr, end_lr, batch_size=64, epochs=1):
         # If x_train contains data for multiple inputs, use length of the first input.
         # Assumption: the first element in the list is single input; NOT a list of inputs.
         N = x_train[0].shape[0] if isinstance(x_train, list) else x_train.shape[0]
-        
-        # Compute number of batches and LR multiplier 
+
+        # Compute number of batches and LR multiplier
         num_batches = epochs * N / batch_size
         self.lr_mult = (float(end_lr) / float(start_lr)) ** (float(1) / float(num_batches))
         # Save weights into a file
         self.model.save_weights('tmp.h5')
 
         # Remember the original learning rate
-        original_lr = K.get_value(self.model.optimizer.lr)
+        original_lr = K.get_value(self.model.optimizer.learning_rate)
 
         # Set the initial learning rate
-        K.set_value(self.model.optimizer.lr, start_lr)
+        K.set_value(self.model.optimizer.learning_rate, start_lr)
 
         callback = LambdaCallback(on_batch_end=lambda batch, logs: self.on_batch_end(batch, logs))
 
         self.model.fit(x_train, y_train,
-                        batch_size=batch_size, epochs=epochs,
-                        callbacks=[callback])
+                       batch_size=batch_size, epochs=epochs,
+                       callbacks=[callback])
 
         # Restore the weights to the state before model fitting
         self.model.load_weights('tmp.h5')
 
         # Restore the original learning rate
-        K.set_value(self.model.optimizer.lr, original_lr)
+        K.set_value(self.model.optimizer.learning_rate, original_lr)
 
     def find_generator(self, generator, start_lr, end_lr, epochs=1, steps_per_epoch=None, **kw_fit):
-            if steps_per_epoch is None:
-                try:
-                    steps_per_epoch = len(generator)
-                except (ValueError, NotImplementedError) as e:
-                    raise e('`steps_per_epoch=None` is only valid for a'
-                            ' generator based on the '
-                            '`keras.utils.Sequence`'
-                            ' class. Please specify `steps_per_epoch` '
-                            'or use the `keras.utils.Sequence` class.')
-            self.lr_mult = (float(end_lr) / float(start_lr)) ** (float(1) / float(epochs * steps_per_epoch))
+        if steps_per_epoch is None:
+            try:
+                steps_per_epoch = len(generator)
+            except (ValueError, NotImplementedError) as e:
+                raise e('`steps_per_epoch=None` is only valid for a'
+                        ' generator based on the '
+                        '`keras.utils.Sequence`'
+                        ' class. Please specify `steps_per_epoch` '
+                        'or use the `keras.utils.Sequence` class.')
+        self.lr_mult = (float(end_lr) / float(start_lr)) ** (float(1) / float(epochs * steps_per_epoch))
 
-            # Save weights into a file
-            self.model.save_weights('tmp.h5')
+        # Save weights into a file
+        self.model.save_weights('tmp.h5')
 
-            # Remember the original learning rate
-            original_lr = K.get_value(self.model.optimizer.lr)
+        # Remember the original learning rate
+        original_lr = K.get_value(self.model.optimizer.learning_rate)
 
-            # Set the initial learning rate
-            K.set_value(self.model.optimizer.lr, start_lr)
+        # Set the initial learning rate
+        K.set_value(self.model.optimizer.learning_rate, start_lr)
 
-            callback = LambdaCallback(on_batch_end=lambda batch,
-                                      logs: self.on_batch_end(batch, logs))
+        callback = LambdaCallback(on_batch_end=lambda batch,
+                                                      logs: self.on_batch_end(batch, logs))
 
-            self.model.fit_generator(generator=generator,
-                                     epochs=epochs,
-                                     steps_per_epoch=steps_per_epoch,
-                                     callbacks=[callback],
-                                     **kw_fit)
+        self.model.fit_generator(generator=generator,
+                                 epochs=epochs,
+                                 steps_per_epoch=steps_per_epoch,
+                                 callbacks=[callback],
+                                 **kw_fit)
 
-            # Restore the weights to the state before model fitting
-            self.model.load_weights('tmp.h5')
+        # Restore the weights to the state before model fitting
+        self.model.load_weights('tmp.h5')
 
-            # Restore the original learning rate
-            K.set_value(self.model.optimizer.lr, original_lr)
+        # Restore the original learning rate
+        K.set_value(self.model.optimizer.learning_rate, original_lr)
 
     def plot_loss(self, n_skip_beginning=10, n_skip_end=5, x_scale='log'):
         """
@@ -115,6 +116,7 @@ class LRFinder:
         plt.plot(self.lrs[n_skip_beginning:-n_skip_end], self.losses[n_skip_beginning:-n_skip_end])
         plt.xscale(x_scale)
         plt.show()
+
     def plot_loss_change(self, sma=1, n_skip_beginning=10, n_skip_end=5, y_lim=(-0.01, 0.01)):
         """
         Plots rate of change of the loss function.
@@ -132,7 +134,7 @@ class LRFinder:
         plt.xscale('log')
         plt.ylim(y_lim)
         plt.show()
-  
+
     def get_derivatives(self, sma):
         assert sma >= 1
         derivatives = [0] * sma


### PR DESCRIPTION
This is a super minor change - just refactoring `model.optimizer.lr` into `model.optimizer.learning_rate` just so it is up to date with the Keras source code. Keras backend still supports using `lr`, but they recommend using `learning_rate`. The actual parameter name in any `keras.optimizers.Optimizer` object is `learning_rate`.

Signed-off-by: tarasivashchuk <taras@tarasivashchuk.com>